### PR TITLE
Fix `WORKDIR` for legacy shell to load libs

### DIFF
--- a/legacy-mongo-shell/Dockerfile
+++ b/legacy-mongo-shell/Dockerfile
@@ -21,6 +21,7 @@ RUN python3 -m pip install -r etc/pip/compile-requirements.txt
 # or add `-j1` parameter to build sequentially.
 RUN python3 buildscripts/scons.py install-mongo
 
+
 FROM mongo:6.0.5
 
 COPY --from=build /mongo/build/install/bin/mongo /usr/bin

--- a/legacy-mongo-shell/Dockerfile
+++ b/legacy-mongo-shell/Dockerfile
@@ -21,13 +21,16 @@ RUN python3 -m pip install -r etc/pip/compile-requirements.txt
 # or add `-j1` parameter to build sequentially.
 RUN python3 buildscripts/scons.py install-mongo
 
-
 FROM mongo:6.0.5
 
 COPY --from=build /mongo/build/install/bin/mongo /usr/bin
-RUN ln -sv /usr/bin/mongo /mongo
 
-WORKDIR /
+RUN mkdir -p /tests/mongo
+
+RUN ln -sv /usr/bin/mongo /tests/mongo/mongo
+
+WORKDIR /tests/mongo
+
 CMD []
 ENTRYPOINT ["mongo"]
 

--- a/legacy-mongo-shell/Dockerfile
+++ b/legacy-mongo-shell/Dockerfile
@@ -24,16 +24,13 @@ RUN python3 buildscripts/scons.py install-mongo
 
 FROM mongo:6.0.5
 
+RUN mkdir /mongo
+
 COPY --from=build /mongo/build/install/bin/mongo /usr/bin
 
-RUN mkdir -p /tests/mongo
+RUN ln -sv /usr/bin/mongo /mongo/mongo
 
-RUN ln -sv /usr/bin/mongo /tests/mongo/mongo
-
-# We need to set WORKDIR as the root directory so that jstest files can load libs etc.,
-# as they use a relative path. We will later mount the jstests directory as a volume
-# in the docker-compose.yml file.
-WORKDIR /tests/mongo
+WORKDIR /mongo
 
 CMD []
 ENTRYPOINT ["mongo"]

--- a/legacy-mongo-shell/Dockerfile
+++ b/legacy-mongo-shell/Dockerfile
@@ -30,8 +30,9 @@ RUN mkdir -p /tests/mongo
 
 RUN ln -sv /usr/bin/mongo /tests/mongo/mongo
 
-# We need to set WORKDIR as the root directory of the repository so that various
-# jstest files can load libs etc., as they use a relative path.
+# We need to set WORKDIR as the root directory so that jstest files can load libs etc.,
+# as they use a relative path. We will later mount the jstest directory as a volume
+# in the docker-compose.yml file.
 WORKDIR /tests/mongo
 
 CMD []

--- a/legacy-mongo-shell/Dockerfile
+++ b/legacy-mongo-shell/Dockerfile
@@ -28,8 +28,11 @@ COPY --from=build /mongo/build/install/bin/mongo /usr/bin
 
 RUN mkdir -p /tests/mongo
 
+#
 RUN ln -sv /usr/bin/mongo /tests/mongo/mongo
 
+# We need to set WORKDIR as the root directory of the repository so that various
+# jstest files can load libs etc., as they use a relative path.
 WORKDIR /tests/mongo
 
 CMD []

--- a/legacy-mongo-shell/Dockerfile
+++ b/legacy-mongo-shell/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p /tests/mongo
 RUN ln -sv /usr/bin/mongo /tests/mongo/mongo
 
 # We need to set WORKDIR as the root directory so that jstest files can load libs etc.,
-# as they use a relative path. We will later mount the jstest directory as a volume
+# as they use a relative path. We will later mount the jstests directory as a volume
 # in the docker-compose.yml file.
 WORKDIR /tests/mongo
 

--- a/legacy-mongo-shell/Dockerfile
+++ b/legacy-mongo-shell/Dockerfile
@@ -28,7 +28,6 @@ COPY --from=build /mongo/build/install/bin/mongo /usr/bin
 
 RUN mkdir -p /tests/mongo
 
-#
 RUN ln -sv /usr/bin/mongo /tests/mongo/mongo
 
 # We need to set WORKDIR as the root directory of the repository so that various


### PR DESCRIPTION
Closes [#295.](https://github.com/FerretDB/dance/issues/295)